### PR TITLE
More privacy: prevent sending even `df.head(1)`: only columns and `dtypes`

### DIFF
--- a/bambooai/bambooai.py
+++ b/bambooai/bambooai.py
@@ -207,7 +207,7 @@ class BambooAI:
             analyst = self.select_analyst(self.select_analyst_messages)
             self.select_analyst_messages.append({"role": "assistant", "content": analyst})
             if analyst == 'Data Analyst DF':
-                self.eval_messages.append({"role": "user", "content": self.planner_user_df.format(question, None if self.df is None else self.df.head(1))})
+                self.eval_messages.append({"role": "user", "content": self.planner_user_df.format(question, None if self.df is None else self.df.dtypes)})
                 # Replace first dict in messages with a new system task
                 self.code_messages[0] = {"role": "system", "content": self.code_generator_system_df}
             elif analyst == 'Data Analyst Generic':
@@ -365,7 +365,7 @@ class BambooAI:
         agent = 'Code Generator'
         # Add a user message with the updated task prompt to the messages list
         if analyst == 'Data Analyst DF':
-            code_messages.append({"role": "user", "content": self.code_generator_user_df.format(None if self.df is None else self.df.head(1), task, self.code_exec_results, example_output)})
+            code_messages.append({"role": "user", "content": self.code_generator_user_df.format(None if self.df is None else self.df.dtypes, task, self.code_exec_results, example_output)})
         elif analyst == 'Data Analyst Generic':
             code_messages.append({"role": "user", "content": self.code_generator_user_gen.format(task, self.code_exec_results, example_output)})
 

--- a/bambooai/output_manager.py
+++ b/bambooai/output_manager.py
@@ -28,7 +28,7 @@ class OutputManager:
     def display_results(self, df=None, answer=None, code=None, rank=None, vector_db=False):
         if 'ipykernel' in sys.modules:
             if df is not None:
-                display(HTML(f'<p><b style="color:{self.color_result_header_ntb};">Here is the head of your dataframe:</b><br><pre style="color:{self.color_result_body_code};">{df.head(5)}</pre></p><br>'))
+                display(HTML(f'<p><b style="color:{self.color_result_header_ntb};">Here is the structure of your dataframe:</b><br><pre style="color:{self.color_result_body_code};">{df.dtypes}</pre></p><br>'))
             if answer is not None:
                 display(HTML(f'<p><b style="color:{self.color_result_header_ntb};">I now have the final answer:</b><br><pre style="color:{self.color_result_body_text}; white-space: pre-wrap; font-weight: bold;">{answer}</pre></p><br>'))
             if code is not None:
@@ -37,8 +37,8 @@ class OutputManager:
                 display(HTML(f'<p><b style="color:{self.color_result_header_ntb};">Solution Rank:</b><br><span style="color:{self.color_result_body_text};">{rank}</span></p><br>'))
         else:
             if df is not None:
-                cprint(f"\n>> Here is the head of your dataframe:", self.color_result_header_cli, attrs=['bold'])
-                self.print_wrapper(df.head(5))
+                cprint(f"\n>> Here is the structure of your dataframe:", self.color_result_header_cli, attrs=['bold'])
+                self.print_wrapper(df.dtypes)
             if answer is not None:
                 cprint(f"\n>> I now have the final answer:\n{answer}", self.color_result_header_cli, attrs=['bold'])
             if code is not None:

--- a/bambooai/prompts.py
+++ b/bambooai/prompts.py
@@ -111,7 +111,7 @@ The user will provide a list of tasks to be accomplished using Python.
 code_generator_user_df = """
 You have been presented with a pandas dataframe named `df`.
 The dataframe df has already been defined and populated with the required data.
-The result of `print(df.head(1))` is:
+The result of `print(df.dtypes)` is:
 {}.
 Return the python code that accomplishes the following tasks: {}.
 Approach each task from the list in isolation, advancing to the next only upon its successful resolution. 


### PR DESCRIPTION
# Problem

Current code sends `df.head(1)` to the LLM, which can be a 3rd party. This can be undesirable for certain use cases in which organizations or stakeholders don't want to risk compromising privacy of their data.

# Solution

The relevant info that the LLM needs is more related with column names and column types than any specific instance of those. In my experience, the performance of the agent is not hurt by this change.