### PR TITLE
Minor Bug in LLM_CONFIG_sample.json

### DIFF
--- a/LLM_CONFIG_sample.json
+++ b/LLM_CONFIG_sample.json
@@ -3,7 +3,7 @@
     {"agent": "Analyst Selector", "details": {"model": "gpt-4-turbo", "provider":"openai","max_tokens": 500, "temperature": 0}},
     {"agent": "Theorist", "details": {"model": "gpt-4-turbo", "provider":"openai","max_tokens": 2000, "temperature": 0}},
     {"agent": "Planner", "details": {"model": "gpt-4-turbo", "provider":"openai","max_tokens": 2000, "temperature": 0}},
-    {"agent": "Code Generator", "details": {"model": "gpt-4-turbo", "provider":"local","max_tokens": 2000, "temperature": 0}},
+    {"agent": "Code Generator", "details": {"model": "gpt-4-turbo", "provider":"openai","max_tokens": 2000, "temperature": 0}},
     {"agent": "Code Debugger", "details": {"model": "gpt-4-turbo", "provider":"openai","max_tokens": 2000, "temperature": 0}},
     {"agent": "Error Corrector", "details": {"model": "gpt-4-turbo", "provider":"openai","max_tokens": 2000, "temperature": 0}},
     {"agent": "Code Ranker", "details": {"model": "gpt-4-turbo", "provider":"openai","max_tokens": 500, "temperature": 0}},


### PR DESCRIPTION
# Problem

The `provider` for the `Code generator` agent in the `LLM_CONFIG_sample.json` was set to `local` instead of `openai`.

This triggered the following bug on code generation:

```py
llm_stream() takes 4 positional arguments but 7 were given
```

# Solution

Correction `provider` from `local` to `openai` in `LLM_CONFIG_sample.json`.